### PR TITLE
Implement booking date validation

### DIFF
--- a/models/Booking.js
+++ b/models/Booking.js
@@ -100,10 +100,10 @@ const bookingSchema = mongoose.Schema(
             return true;
           }
           const minDate = new Date();
-          minDate.setDate(minDate.getDate() + 7);
+          minDate.setDate(minDate.getDate() + 2);
           return value >= minDate;
         },
-        message: "Booking date must be at least 7 days from today"
+        message: "Booking date must be at least 2 days from today"
       }
     },
     location: {

--- a/pages/api/user/bookings.js
+++ b/pages/api/user/bookings.js
@@ -163,12 +163,12 @@ export default async function handler(req, res) {
       if (sanitizedUpdates.date) {
         const bookingDate = new Date(sanitizedUpdates.date);
         const minDate = new Date();
-        minDate.setDate(minDate.getDate() + 7);
+        minDate.setDate(minDate.getDate() + 2);
         
         if (bookingDate < minDate || isNaN(bookingDate.getTime())) {
           return res.status(400).json({
             error: 'Invalid date',
-            message: 'Booking date must be at least 7 days from today'
+            message: 'Booking date must be at least 2 days from today'
           });
         }
       }


### PR DESCRIPTION
Standardize booking date validation to 2 days minimum to resolve inconsistencies between frontend and backend.

Previously, the frontend and public API allowed bookings 2 days in advance, but the backend database model and user API enforced a 7-day minimum. This led to a confusing user experience where valid frontend selections were rejected by the backend. This PR aligns all validation to the intended 2-day minimum as per `BOOKING_FIXES.md`.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-4c6c04fd-9832-407a-a05e-0c8d6bbe195b) · [Cursor](https://cursor.com/background-agent?bcId=bc-4c6c04fd-9832-407a-a05e-0c8d6bbe195b)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)