### PR TITLE
Update booking management system URL

### DIFF
--- a/pages/api/bookings.js
+++ b/pages/api/bookings.js
@@ -292,7 +292,7 @@ export default async function handler(req, res) {
         if (shouldSend) {
           await sendBookingConfirmationEmail(savedBooking, { 
             hasAccount: true,
-            loginUrl: `https://${process.env.VERCEL_URL || config.domainName}/dashboard`
+            loginUrl: `https://${config.domainName}/dashboard`
           });
           emailSent = true;
         }
@@ -300,7 +300,7 @@ export default async function handler(req, res) {
         // For non-authenticated users, always send confirmation with account creation prompt
         await sendBookingConfirmationEmail(savedBooking, { 
           hasAccount: false,
-          loginUrl: `https://${process.env.VERCEL_URL || config.domainName}/login`
+          loginUrl: `https://${config.domainName}/login`
         });
         emailSent = true;
       }


### PR DESCRIPTION
Fix booking confirmation email URLs to use the production domain.
Previously, `process.env.VERCEL_URL` was used, which could lead to preview or development URLs being sent in production emails.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-24a489e8-84d1-4892-8e87-5653694737aa) · [Cursor](https://cursor.com/background-agent?bcId=bc-24a489e8-84d1-4892-8e87-5653694737aa)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)