### PR TITLE
Fix inactive new user accounts

### DIFF
--- a/libs/next-auth.js
+++ b/libs/next-auth.js
@@ -101,6 +101,10 @@ export const authOptions = {
               );
               console.log('✅ Updated OAuth account with new Google provider details');
             }
+          } else {
+            // New OAuth user - they will be created by the adapter
+            // We'll set hasAccess to true in the events callback below
+            console.log(`New OAuth user will be created for ${profile.email}`);
           }
         } catch (error) {
           console.error('Error in signIn callback:', error);
@@ -287,6 +291,24 @@ export const authOptions = {
             await invitation.save();
             
             console.log(`Invitation accepted for new user ${message.user.email}`);
+          } else {
+            // No invitation found - this is a new OAuth user signing up directly
+            // Grant access by default for OAuth users since they've authenticated with a trusted provider
+            console.log(`No invitation found for new OAuth user ${message.user.email} - granting default access`);
+            newUser.hasAccess = true;
+            newUser.role = newUser.role || 'client'; // Ensure role is set
+            
+            // Add to access history for tracking
+            if (!newUser.accessHistory) {
+              newUser.accessHistory = [];
+            }
+            newUser.accessHistory.push({
+              hasAccess: true,
+              changedAt: new Date(),
+              changedBy: 'system',
+              reason: 'Auto-granted access for OAuth user',
+              action: 'created'
+            });
           }
           
           await newUser.save();


### PR DESCRIPTION
Automatically grant access to new OAuth users to prevent immediate account suspension.

When users signed in via Google OAuth for the first time, NextAuth's MongoDB adapter created their account with `hasAccess: false` by default, preventing them from logging in. This PR modifies the `createUser` event in `libs/next-auth.js` to set `hasAccess: true` for new OAuth users who do not have a pending invitation, ensuring they can access their account immediately.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-06675142-d986-4b66-a16e-5095a3aa8f70) · [Cursor](https://cursor.com/background-agent?bcId=bc-06675142-d986-4b66-a16e-5095a3aa8f70)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)